### PR TITLE
Updated the "Then I can't continue" step with the following variants:

### DIFF
--- a/lib/steps.js
+++ b/lib/steps.js
@@ -417,7 +417,7 @@ Then('an element should have the id {string}', async ( id ) => {  // √
 // });
 
 // This is phrase is confusing. It sounds like it's going to at least try to continue.
-Then(/I (don't|can't) continue/, async (unused) => {  // √
+Then(/I (don't|can't|don’t|can’t|cannot|do not) continue/, async (unused) => {  // √
   /* Tests for detection of url change from button or link tap.
   *    Can other things trigger navigation? Re: other inputs things
   *    like 'Enter' acting like a click is a test for docassemble */

--- a/tests/features/assembly_line.feature
+++ b/tests/features/assembly_line.feature
@@ -3,8 +3,11 @@ Feature: Assembly Line package-specific Steps
 
 # In tag names, 'al' is for 'assembly line'
 
+# Note: the first test for this suite is the first test in this file and we're having timeout issues, so we're trying to give the server longer to load.
+
 @fast @al1
 Scenario: I have two name parts
+  Given the max secs for each step is 120
   Given I start the interview at "AL_tests"
   And I set the name of "users[0]" to "Uli User"
   And I tap to continue

--- a/tests/features/observation_steps.feature
+++ b/tests/features/observation_steps.feature
@@ -24,51 +24,6 @@ Scenario: I see user errors.
   Then I can't continue
   And I will be told an answer is invalid
 
-@fast @o2
-Scenario: Test "Then I don't continue" with a single quote
-  Given I start the interview at "all_tests"
-  And I tap to continue
-  And I tap to continue
-  And I tap to continue
-  Then I don't continue
-  And I will be told an answer is invalid
-
-@fast @o2
-Scenario: Test "Then I cannot continue"
-  Given I start the interview at "all_tests"
-  And I tap to continue
-  And I tap to continue
-  And I tap to continue
-  Then I cannot continue
-  And I will be told an answer is invalid
-
-@fast @o2
-Scenario: Test "Then I do not continue"
-  Given I start the interview at "all_tests"
-  And I tap to continue
-  And I tap to continue
-  And I tap to continue
-  Then I do not continue
-  And I will be told an answer is invalid
-
-@fast @o2
-Scenario: Test "Then I can’t continue" with an apostrophe
-  Given I start the interview at "all_tests"
-  And I tap to continue
-  And I tap to continue
-  And I tap to continue
-  Then I can’t continue
-  And I will be told an answer is invalid
-
-@fast @o2
-Scenario: Test "Then I don’t continue" with an apostrophe
-  Given I start the interview at "all_tests"
-  And I tap to continue
-  And I tap to continue
-  And I tap to continue
-  Then I don’t continue
-  And I will be told an answer is invalid
-
 @fast @o3
 Scenario: I can include .yml in the filename
   Given I start the interview at "all_tests.yml"
@@ -95,3 +50,48 @@ Scenario: I check navigation
     | buttons_other | button_2 |  |
     | buttons_yesnomaybe | True |  |
   And I should see the link to "http://ecosia.org/"
+
+@fast @o4
+Scenario: Test "Then I don't continue" with a single quote
+  Given I start the interview at "all_tests"
+  And I tap to continue
+  And I tap to continue
+  And I tap to continue
+  Then I don't continue
+  And I will be told an answer is invalid
+
+@fast @o5
+Scenario: Test "Then I cannot continue"
+  Given I start the interview at "all_tests"
+  And I tap to continue
+  And I tap to continue
+  And I tap to continue
+  Then I cannot continue
+  And I will be told an answer is invalid
+
+@fast @o6
+Scenario: Test "Then I do not continue"
+  Given I start the interview at "all_tests"
+  And I tap to continue
+  And I tap to continue
+  And I tap to continue
+  Then I do not continue
+  And I will be told an answer is invalid
+
+@fast @o7
+Scenario: Test "Then I can’t continue" with an apostrophe
+  Given I start the interview at "all_tests"
+  And I tap to continue
+  And I tap to continue
+  And I tap to continue
+  Then I can’t continue
+  And I will be told an answer is invalid
+
+@fast @o8
+Scenario: Test "Then I don’t continue" with an apostrophe
+  Given I start the interview at "all_tests"
+  And I tap to continue
+  And I tap to continue
+  And I tap to continue
+  Then I don’t continue
+  And I will be told an answer is invalid

--- a/tests/features/observation_steps.feature
+++ b/tests/features/observation_steps.feature
@@ -15,12 +15,58 @@ Scenario: I observe things on a single page when I arrive
   And an element should have the id "daform"
 
 @fast @o2
-Scenario: I see user errors
+Scenario: I see user errors.
+#  They're everywhere.  Some don't even know they are errors.
   Given I start the interview at "all_tests"
   And I tap to continue
   And I tap to continue
   And I tap to continue
   Then I can't continue
+  And I will be told an answer is invalid
+
+@fast @o2
+Scenario: Test "Then I don't continue" with a single quote
+  Given I start the interview at "all_tests"
+  And I tap to continue
+  And I tap to continue
+  And I tap to continue
+  Then I don't continue
+  And I will be told an answer is invalid
+
+@fast @o2
+Scenario: Test "Then I cannot continue"
+  Given I start the interview at "all_tests"
+  And I tap to continue
+  And I tap to continue
+  And I tap to continue
+  Then I cannot continue
+  And I will be told an answer is invalid
+
+@fast @o2
+Scenario: Test "Then I do not continue"
+  Given I start the interview at "all_tests"
+  And I tap to continue
+  And I tap to continue
+  And I tap to continue
+  Then I do not continue
+  And I will be told an answer is invalid
+
+@fast @o2
+Scenario: Test "Then I can’t continue" with an apostrophe
+  Given I start the interview at "all_tests"
+  And I tap to continue
+  And I tap to continue
+  And I tap to continue
+  Then I can’t continue
+  And I will be told an answer is invalid
+
+@fast @o2
+Scenario: Test "Then I don’t continue" with an apostrophe
+  Given I start the interview at "all_tests"
+  And I tap to continue
+  And I tap to continue
+  And I tap to continue
+  Then I don’t continue
   And I will be told an answer is invalid
 
 @fast @o3


### PR DESCRIPTION
* Then I cannot continue
* Then I do not continue
* Then I can’t continue (using a Unicode apostrophe)
* Then I don’t continue (ditto)

This should make it easier to copy and paste test steps from a PDF or
Word.

Closes #152 