### PR TITLE
Close #417, fix private repos don't get pulled into package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ Format:
 - 
 -->
 <!-- ## [Unreleased] -->
+
+## [3.0.2] - 2021-12-10
+### Changed
+- Improve some error messages and handling for the new private repo workflow.
+
+## [3.0.1] - 2021-12-10
+### Fixed
+- Allow authenticated GitHub user to pull from a private repository for which they have at least read permissions.
+
 ## [3.0.0] - 2021-12-07
 ### Changed
 - v3 release to update to da Bootstrap 5. Breaks for servers that have not yet updated to that da version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ Format:
 -->
 <!-- ## [Unreleased] -->
 
+## [3.0.4] - 2021-12-11
+### Fixed
+- Use different criteria for testing that the package was saved.
+
 ## [3.0.3] - 2021-12-11
 ### Fixed
 - Implement a temporary fix for inability to pull private repos into empty da Projects. See https://github.com/SuffolkLITLab/ALKiln/issues/417#issuecomment-991812294

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ Format:
 -->
 <!-- ## [Unreleased] -->
 
+## [3.0.3] - 2021-12-11
+### Fixed
+- Implement a temporary fix for inability to pull private repos into empty da Projects. See https://github.com/SuffolkLITLab/ALKiln/issues/417#issuecomment-991812294
+
 ## [3.0.2] - 2021-12-10
 ### Changed
 - Improve some error messages and handling for the new private repo workflow.

--- a/lib/github_integration/install-branch.js
+++ b/lib/github_integration/install-branch.js
@@ -10,8 +10,12 @@ const setup = async () => {
     await waitForPage(page);  // Ensure server has really restarted
   }
   catch (e) {
-    await page.screenshot({ path: `error-settingUp.jpg`, type: 'jpeg', fullPage: true });
-    throw e;
+    try {
+      await page.screenshot({ path: `error-settingUp.jpg`, type: 'jpeg', fullPage: true });
+    } catch ( error ) {
+      console.log( `Could not take screenshot of repo setup error.\n` );
+      throw e;
+    }
   }
   finally {
     browser.close();

--- a/lib/github_integration/puppeteer-utils.js
+++ b/lib/github_integration/puppeteer-utils.js
@@ -144,8 +144,25 @@ const tap_pull = async ( page, elem_to_blur ) => {
 }
 
 const installRepo = async (page) => {
-  await page.goto(installUrl(), {waitUntil: 'domcontentloaded'});
+  // await page.goto(installUrl(), {waitUntil: 'domcontentloaded'});
+  // `https://apps-dev.suffolklitlab.org/playgroundpackages?project=EmptyProject`
+  let package_url = `${ env_vars.BASE_URL }/playgroundpackages?project=${ env_vars.getProjectName() }`;
+  await page.goto(package_url, {waitUntil: 'domcontentloaded'});
 
+  // Without this temporary workaround, a current bug will not
+  // allow you to pull from a private repo if the Project is empty.
+  // For now, we'll make a package first so it's not empty.
+  let package_input = await page.$( `#file_name` );
+  await package_input.type( `TemporaryFix` );
+  let save_button = await page.$( `button[value="Save"]` );
+  Promise.all([
+    save_button.evaluate( (el) => { return el.click(); }),
+    page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
+  ]);
+  // Waiting for navigation isn't enough.
+  await page.waitForSelector(`#file_name`, { visible: true })
+
+  await page.goto(installUrl(), {waitUntil: 'domcontentloaded'});
   // For private repos especially, needs the format
   // git@github.com:user/docassemble-package.git from original
   // format https://github.com/user/docassemble-package

--- a/lib/github_integration/puppeteer-utils.js
+++ b/lib/github_integration/puppeteer-utils.js
@@ -160,7 +160,8 @@ const installRepo = async (page) => {
     page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
   ]);
   // Waiting for navigation isn't enough.
-  await page.waitForSelector(`#file_name`, { visible: true })
+  await page.waitFor( 1000 );
+  await page.waitForSelector(`#daDelete`, { visible: true });
 
   await page.goto(installUrl(), {waitUntil: 'domcontentloaded'});
   // For private repos especially, needs the format

--- a/lib/github_integration/puppeteer-utils.js
+++ b/lib/github_integration/puppeteer-utils.js
@@ -178,7 +178,15 @@ const installRepo = async (page) => {
 
   // Try just the regular env_vars.REPO_URL
   if ( permissions_failed ) {
-    console.log( `If this is a private repo, pay attention to the following: we tried to pull the package using the testing account's docassemble GitHub integration and the address git@github.com:${ user }/${ package }.git. It looks like the testing account is either not integrated with GitHub or the testing account GitHub account does not have permissions in this private GitHub repo. Try setting up the GitHub permissions for that docassemble testing account. If you're sure you have already done so, make an issue at https://github.com/SuffolkLITLab/ALKiln/issues.\n` );
+    let permissions_msg = `If this is a private repo, pay attention to the following: `
+      + `we tried to pull the package using the testing account's docassemble GitHub `
+      + `integration and the address git@github.com:${ user }/${ package }.git. It `
+      + `looks like the testing account is either not integrated with GitHub or the `
+      + `testing account GitHub account does not have permissions in this private `
+      + `GitHub repo. Try setting up the GitHub permissions for that docassemble `
+      + `testing account. If you're sure you have already done so, make an issue at `
+      + `https://github.com/SuffolkLITLab/ALKiln/issues.\n`
+    console.log( permissions_msg );
     await page.goto(installUrl(), {waitUntil: 'domcontentloaded'});
     repo_input = await page.$( `#github_url` );  // new page, new input element
     await repo_input.type( env_vars.REPO_URL );

--- a/lib/github_integration/puppeteer-utils.js
+++ b/lib/github_integration/puppeteer-utils.js
@@ -109,8 +109,8 @@ const deleteProject = async (page) => {
 const installUrl = function () {
   let params_for_url =  urlParams({
     project: env_vars.getProjectName(),
-    github: env_vars.REPO_URL,
-    branch: env_vars.BRANCH_NAME,
+    // github: env_vars.REPO_URL,
+    // branch: env_vars.BRANCH_NAME,  // Did not seem to have the desired effect
   });
   return `${ env_vars.BASE_URL }/pullplaygroundpackage?${ params_for_url }`;
 };
@@ -119,25 +119,74 @@ const urlParams = (params) => urlString = Object.keys(params).map(
   (key) => `${key}=${params[key]}`
 ).join('&')
 
+const tap_pull = async ( page, elem_to_blur ) => {
+  await elem_to_blur.evaluate((elem) => { elem.blur(); });
+
+  try {
+    // Wait for the options to appear after the ajax call
+    let optSelector = '[value="' + env_vars.BRANCH_NAME + '"]';
+    console.log( `Looking for the ${ env_vars.BRANCH_NAME } branch of the repository at ${ env_vars.REPO_URL }.\n` );
+    await page.waitFor( optSelector );  // This is the key
+    console.log( `We found the ${ env_vars.BRANCH_NAME } branch of the repository at ${ env_vars.REPO_URL }. Next, we will try to pull the code.\n` );
+    let html = await page.$eval( optSelector, (elem) => { return elem.innerHTML });  // Why are we doing this?
+  
+    // Tap 'Pull' and wait till the page has finished loading
+    const pullButton = await page.$('button[name=pull]');
+    await Promise.all([
+      pullButton.click(),
+      page.waitForNavigation({waitUntil: 'domcontentloaded'}),
+    ]);
+  } catch ( error ) {
+    return { succeeded: false, error: error };
+  }
+
+  return { succeeded: true, error: null };
+}
+
 const installRepo = async (page) => {
   await page.goto(installUrl(), {waitUntil: 'domcontentloaded'});
 
-  // Wait for the options to appear after the ajax call
-  let optSelector = '[value="' + env_vars.BRANCH_NAME + '"]';
-  await page.waitFor( optSelector );  // This is the key
-  let html = await page.$eval( optSelector, (elem) => { return elem.innerHTML });
+  // For private repos especially, needs the format
+  // git@github.com:user/docassemble-package.git from original
+  // format https://github.com/user/docassemble-package
+  let user = env_vars.REPO_URL.split("/")[3];
+  let package = env_vars.REPO_URL.split("/")[4];
+  let repo_input = await page.$( `#github_url` );
+  await repo_input.type( `git@github.com:${ user }/${ package }.git` );
 
-  // Tap 'Pull' and wait till the page has finished loading
-  const pullButton = await page.$('button[name=pull]');
-  await Promise.all([
-    pullButton.click(),
-    page.waitForNavigation({waitUntil: 'domcontentloaded'}),
+  let result = await tap_pull( page, repo_input );
+
+  // if body contains "Could not read from remote repository"
+  let permissions_failed = await page.$eval(`body`, function (elem) {
+    return elem.innerText.includes("Could not read from remote repository");
+  });
+
+  // Try just the regular env_vars.REPO_URL
+  if ( permissions_failed ) {
+    console.log( `If this is a private repo, pay attention to the following: we tried to pull the package using the testing account's docassemble GitHub integration and the address git@github.com:${ user }/${ package }.git. It looks like the testing account is either not integrated with GitHub or the testing account GitHub account does not have permissions in this private GitHub repo. Try setting up the GitHub permissions for that docassemble testing account. If you're sure you have already done so, make an issue at https://github.com/SuffolkLITLab/ALKiln/issues.\n` );
+    await page.goto(installUrl(), {waitUntil: 'domcontentloaded'});
+    repo_input = await page.$( `#github_url` );  // new page, new input element
+    await repo_input.type( env_vars.REPO_URL );
+    result = await tap_pull( page, repo_input );
+    if ( result.error ) { throw result.error; }
+  } else if ( result.error ) {
+    // If there was a different problem, throw that error
+    throw result.error;
+  }
+  // What's a better way to handle this in the future?
+  // With the API, check if the user has GitHub integration set up.
+
+  // After all the pulling has been tried that needs to be tried, wait for loading to finish
+  try {
     // server/module reload. See https://github.com/plocket/docassemble-cucumber/issues/367#issuecomment-892591770
     // The selector find the 'Package Name' field on the 'Packages' page
-    page.waitForSelector(`#file_name`, { visible: true }),
-  ]);
+    await page.waitForSelector(`#file_name`, { visible: true })
+  } catch ( error ) {
+    console.log( `It looks like pulling the ${ env_vars.BRANCH_NAME } branch of the repository at ${ env_vars.REPO_URL } failed. Download the error screenshots in the GitHub Action artifacts to see if it tells you more.\n` );
+    throw error ;
+  }
 
-  console.log( `Pulled the GitHub branch "${ env_vars.BRANCH_NAME }" into the project "${ env_vars.getProjectName() }".` );
+  console.log( `Pulled the GitHub branch "${ env_vars.BRANCH_NAME }" into the project "${ env_vars.getProjectName() }".\n` );
 }
 
 

--- a/lib/github_integration/puppeteer-utils.js
+++ b/lib/github_integration/puppeteer-utils.js
@@ -107,11 +107,8 @@ const deleteProject = async (page) => {
 };
 
 const installUrl = function () {
-  let params_for_url =  urlParams({
-    project: env_vars.getProjectName(),
-    // github: env_vars.REPO_URL,
-    // branch: env_vars.BRANCH_NAME,  // Did not seem to have the desired effect
-  });
+  // Because of private repo issues (#417), can't use `github` url arg
+  let params_for_url =  urlParams({ project: env_vars.getProjectName() });
   return `${ env_vars.BASE_URL }/pullplaygroundpackage?${ params_for_url }`;
 };
 

--- a/lib/github_integration/puppeteer-utils.js
+++ b/lib/github_integration/puppeteer-utils.js
@@ -183,9 +183,10 @@ const installRepo = async (page) => {
     repo_input = await page.$( `#github_url` );  // new page, new input element
     await repo_input.type( env_vars.REPO_URL );
     result = await tap_pull( page, repo_input );
-    if ( result.error ) { throw result.error; }
-  } else if ( result.error ) {
-    // If there was a different problem, throw that error
+  } 
+  
+  if ( result.error ) {
+    // If there was a problem, either originally or with the private repo code, throw that error
     throw result.error;
   }
   // What's a better way to handle this in the future?

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Closes #417. Other than the title, the details are in the issue itself. This includes a workaround for a current da bug. This is already published to allow folks to work with their private repos, but it can still be improved and changed based on review.