### PR TITLE
Close #420, simplify subscriber workflow with our own action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,10 +39,12 @@ Format:
 - 
 -->
 <!-- ## [Unreleased] -->
+### Added
+- Add action.yml that runs most of what users' workflows run now, along with notes for a new user workflow that will take less maintainance. See #420. We need to add documentation on how to write a workflow file as it currently is if they want to take back control. Setup interview has not yet been updated with this workflow.
 
 <!-- ## [3.0.1-peer-deps.1] - 2021-12-07 -->
-### Changed
-- Peer dependencies and dev dependencies. Now `cucumber` is just a dependency. See https://github.com/SuffolkLITLab/ALKiln/issues/396 for discussion.
+### Removed
+- Peer dependencies and dev dependencies. Now `cucumber` is just a dependency. See https://github.com/SuffolkLITLab/ALKiln/issues/396 for discussion. Setup interview has not been updated to remove dependencies.
 
 
 ## [3.0.4] - 2021-12-11

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,133 @@
+name: "ALKiln: Automated docassemble tests"
+description: "Automatically test any docassemble interview in a any branch on your GitHub repository whenever you commit or push. See https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing."
+
+inputs:
+  SERVER_URL:
+    description: 'The url of your docassemble server. This should be in your GitHub SECRETS or the SECRETS of your org.'
+    required: true
+  PLAYGROUND_EMAIL:
+    description: 'The email of your docassemble testing account. This should be in your GitHub SECRETS or the SECRETS of your org.'
+    required: true
+  PLAYGROUND_PASSWORD:
+    description: 'The password of your docassemble testing account. This should be in your GitHub SECRETS or the SECRETS of your org.'
+    required: true
+  PLAYGROUND_ID:
+    description: 'The id of your docassemble testing account. This should be in your GitHub SECRETS or the SECRETS of your org.'
+    required: true
+  EXTRA_LANGUAGES:
+    description: 'Other languages you want to test. This should be in your GitHub SECRETS or the SECRETS of your org.'
+    required: false
+    default: ''
+
+runs:
+  using: "composite"
+  steps:
+    # Install node
+    - name: "ALKiln: Install node package manager"
+      uses: actions/setup-node@v1
+      with:
+        node-version: "12"
+    - run: npm install
+      shell: bash
+
+    # Set environment variables
+    - name: "ALKiln: Set environment variables"
+      # If extra languages were set manually, override the repository
+      # EXTRA_LANGUAGES secret with the manually set values
+      run: |
+        if ${{ github.event.inputs.extra_languages != '' }}
+        then
+          echo "Manually set languages: ${{ github.event.inputs.extra_languages }}"
+          echo "EXTRA_LANGUAGES=${{ github.event.inputs.extra_languages }}" >> $GITHUB_ENV
+        else
+          echo "Use EXTRA_LANGUAGES secret: ${{ inputs.EXTRA_LANGUAGES }}"
+          echo "EXTRA_LANGUAGES=${{ inputs.EXTRA_LANGUAGES }}" >> $GITHUB_ENV
+        fi
+        echo "REPO_URL=${{ github.server_url }}/${{ github.repository }}" >> $GITHUB_ENV
+        echo "BRANCH_PATH=${{ github.ref }}" >> $GITHUB_ENV
+        echo "BASE_URL=${{ inputs.SERVER_URL }}" >> $GITHUB_ENV
+        echo "PLAYGROUND_EMAIL=${{ inputs.PLAYGROUND_EMAIL }}" >> $GITHUB_ENV
+        echo "PLAYGROUND_PASSWORD=${{ inputs.PLAYGROUND_PASSWORD }}" >> $GITHUB_ENV
+        echo "PLAYGROUND_ID=${{ inputs.PLAYGROUND_ID }}" >> $GITHUB_ENV
+      shell: bash
+    - name: "ALKiln: confirm info"
+      run: echo -e "\nRepo is $REPO_URL\nBranch ref is $BRANCH_PATH\nManually added languages are $EXTRA_LANGUAGES\nAll other data is secret\n"
+      shell: bash
+
+    # Run tests
+    - name: "ALKiln: Create a Project and pull the package from GitHub"
+      run: npm run setup
+      shell: bash
+    - name: "ALKiln: Run tests"
+      if: ${{ success() }}
+      run: npm run test -- ${{ github.event.inputs.tags && format('"--tags" "{0}"', github.event.inputs.tags) }}
+      shell: bash
+    - run: echo -e "\n\n====ALKiln could not create a project on your server's testing account or pull your package into it. Check the messages above this line.\n\n"
+      if: ${{ failure() }}
+      shell: bash
+    - name: "ALKiln: Delete project from docassemble test account"
+      if: ${{ always() }}
+      run: npm run takedown
+      shell: bash
+
+    # Upload artifacts that subscribers can download on the Actions summary page
+    - name: "ALKiln: Upload errors to action summary artifacts"
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: errors
+        path: ./**/error*.jpg
+    - name: "ALKiln: Upload screenshots to action summary artifacts"
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: screenshots
+        path: ./**/screenshot*.jpg
+    - name: "ALKiln: Upload downloaded files to action summary artifacts"
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: downloads
+        path: ./**/downloads_*
+    - name: "ALKiln: Upload report to action summary artifacts"
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: report
+        path: ./**/*_report_*
+
+# ##################################
+# # A developer's workflow should look similar to the below
+# # In place of `uses: suffolkLITLab/ALKiln@releases/v4`, they
+# # might use another version.
+
+# name: Use the ALKiln testing framework
+# description: "Use the ALKiln testing framework to test interviews. See https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing."
+
+# on:
+#   push:
+#   workflow_dispatch:
+#     inputs:
+#       extra_languages:
+#         description: 'Optional. A list of comma separated language names visible on buttons or links in the interview that change the language of the interview. Overrides the EXTRA_LANGUAGES GitHub secret.'
+#         default: ''
+#       tags:
+#         description: 'Optional. Use a "tag expression" specify which tagged tests to run. See https://cucumber.io/docs/cucumber/api/#tag-expressions for syntax.'
+#         default: ''
+
+# jobs:
+
+#   interview-testing:
+#     runs-on: ubuntu-latest
+#     name: Run interview tests
+#     steps:
+#       - uses: actions/checkout@v2
+#       - name: Use ALKiln to run tests
+#         uses: suffolkLITLab/ALKiln@releases/v4
+#         with:
+#           SERVER_URL: "${{ secrets.SERVER_URL }}"
+#           PLAYGROUND_EMAIL: "${{ secrets.PLAYGROUND_EMAIL }}"
+#           PLAYGROUND_PASSWORD: "${{ secrets.PLAYGROUND_PASSWORD }}"
+#           PLAYGROUND_ID: "${{ secrets.PLAYGROUND_ID }}"
+#           EXTRA_LANGUAGES: "${{ secrets.EXTRA_LANGUAGES }}"
+#       - run: echo "Finished running ALKiln tests"


### PR DESCRIPTION
It's a composite action. The corresponding user action will be
added to the setup interview. This doesn't break anything that's
working now, just sets us up to provide the simpler workflow in
the future.

Closes #420, though the unanswered questions in there should be
turned into their own issue(s)

Still to be answered:

How do we version this? At least for this first bit. Shall we make a tag release now and, for now, just keep updating it? I think we really need automation to make this workflow work. See https://github.com/SuffolkLITLab/ALKiln/issues/420#issuecomment-993959965 and possibly additional relevant questions there.