### PR TITLE
Fix interview name not allowing url parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ Format:
 ### Removed
 - Peer dependencies and dev dependencies. Now `cucumber` is just a dependency. See https://github.com/SuffolkLITLab/ALKiln/issues/396 for discussion. Setup interview has not been updated to remove dependencies.
 
+### Fixed
+- Fixed interview name not allowing url parameters. #449
+
 
 ## [3.0.4] - 2021-12-11
 ### Fixed

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -322,8 +322,9 @@ module.exports = {
     }
     if ( !scope.page ) { scope.page = await scope.browser.newPage(); }
 
-    if ( !file_name.endsWith('.yml') ) { file_name = `${ file_name }.yml` }
+    if ( !file_name.includes('.yml') ) { file_name = `${ file_name }.yml` }
     let interview_url = `${ env_vars.getBaseInterviewURL() }${ file_name }`;
+    if ( env_vars.DEBUG ) { console.log( interview_url ); }
 
     await scope.page.goto(interview_url, { waitUntil: 'domcontentloaded', timeout: scope.timeout })
 

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -113,8 +113,8 @@ Given(/I start the interview at "([^"]+)"(?: in lang "([^"]+)")?/, {timeout: -1}
   while ( num_attempts < max_load_attempts ) {
 
     num_attempts++;
-    let timeout_message = `Failed to load "${ file_name }" after ${ num_attempts } tries.` +
-      `Each try gave the page ${ scope.timeout/1000 } seconds to load.`;
+    let timeout_message = `Failed to load "${ file_name }" after ${ num_attempts } tries. `
+      + `Each try gave the page ${ scope.timeout/1000 } seconds to load.`;
     
     let loaded = new Promise(async ( resolve, reject ) => {
       // Exit if timeout is exceeded. Reject only if final attempt failed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "3.0.4",
+  "version": "3.0.5-hotfix-url-args.1",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/tests/features/establishing_steps.feature
+++ b/tests/features/establishing_steps.feature
@@ -15,3 +15,8 @@ Scenario: I am able to set a custom wait time before an interview has been loade
   Given the max seconds for each step in this scenario is 40
   And I start the interview at "all_tests"
   And I wait 35 seconds
+
+@fast @e3 @urlargs
+Scenario: Interview name includes url args
+  Given I start the interview at "url_args.yml&from=theinternets&random=zoo"
+  Then I should see the phrase "zoo"


### PR DESCRIPTION
Close #449, can't add url parameters/url arguments to interview name. Let me know if this seems robust enough.

[Also noticed typo in error message. That should probably have been saved for some bit typo PR, so I can remove it if preferred.]