### PR TITLE
Allow a developer to wait as a first Step for v3. Address #387. Add test.

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1583,7 +1583,7 @@ module.exports = {
   },  // Ends scope.reportIncludesAllExpected()
 
   waitFor: async function ( scope, options ) {
-    let { milliseconds } = options || 0;
+    let { milliseconds } = options || { milliseconds: 0 };
     return new Promise(resolve => setTimeout(resolve, milliseconds));
   },
 };

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1580,4 +1580,9 @@ module.exports = {
 
     return all_are_included;
   },  // Ends scope.reportIncludesAllExpected()
+
+  waitFor: async function ( scope, options ) {
+    let { milliseconds } = options || 0;
+    return new Promise(resolve => setTimeout(resolve, milliseconds));
+  },
 };

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -380,7 +380,14 @@ When(/I wait (\d*\.?\d+) seconds?/, async (seconds) => {  // √
   // Shoudl any observational things reset the 'navigated' flag?
   // Maybe the 'navitaged' flag should only be reset just before trying to
   // navigate (after pressing a button)
-  await scope.afterStep(scope, {waitForTimeout: (parseFloat(seconds) * 1000)});
+  let ms = parseFloat( seconds ) * 1000;
+
+  if ( scope.page ) {
+    await scope.afterStep(scope, { waitForTimeout: ms });
+  } else {
+    // TODO: Replace with util waiting function in another PR
+    await scope.waitFor( scope, { milliseconds: ms });
+  }
 });
 
 Then(/I take a screenshot ?(?:named "([^"]+)")?/, async ( name ) => {
@@ -821,14 +828,15 @@ After(async function(scenario) {
     if ( env_vars.DEBUG ) {
       // When debugging locally, pause to allow dev to examine the page
       console.log( `Error occurred while running test` );
-      await scope.page.waitFor( 60 * 1000 );
+      if ( scope.page ) { await scope.page.waitFor( 60 * 1000 ); }
     }
 
     await scope.addToReport(scope, { type: `outcome`, value: `**-- Scenario Failed --**` });
     // Save/download a picture of the screen during the error
-    let safe_filename = await scope.getSafeScenarioFilename( scope, { prefix: `error` });
-    await scope.page.screenshot({ path: `${ safe_filename }.jpg`, type: `jpeg`, fullPage: true });
-
+    if ( scope.page ) {
+      let safe_filename = await scope.getSafeScenarioFilename( scope, { prefix: `error` });
+      await scope.page.screenshot({ path: `${ safe_filename }.jpg`, type: `jpeg`, fullPage: true });
+    }
   }
 
   let original_scenario_status = scenario.result.status;
@@ -873,7 +881,8 @@ After(async function(scenario) {
     
     await scope.page.close();
     scope.page = null;
-  }
+  }  // ends if scope.page
+
 });
 
 AfterAll(async function() {

--- a/tests/features/establishing_steps.feature
+++ b/tests/features/establishing_steps.feature
@@ -15,3 +15,7 @@ Scenario: I am able to set a custom wait time before an interview has been loade
   Given the max seconds for each step in this scenario is 40
   And I start the interview at "all_tests"
   And I wait 35 seconds
+
+@slow @e3 @wait_first
+Scenario: I can wait as a first step in a test
+  Given I wait 1 second


### PR DESCRIPTION
This adds a temporary function for waiting in scope.js that will soon be replaced by a singular function in the utils folder. That said, that function is part of v4 changes, and this can improve v3 as well, so we might as well not wait.

Addresses #387, after a little confusion. Should add this to the testing docs as a 'first step' after this is merged.

[Also, generally adds safety measures for when `page` does not exist.]

[v4 has to wait till API PR is accepted.]