### PR TITLE
Fix #464, story table row matches on wrong trigger var when there's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ Format:
 ### Removed
 - Peer dependencies and dev dependencies. Now `cucumber` is just a dependency. See https://github.com/SuffolkLITLab/ALKiln/issues/396 for discussion. Setup interview has not been updated to remove dependencies.
 
+### Fixed
+- Proxy var story table row matches for any page containing the given variable name when there's only one row for the relevant variable. #464.
+
 
 ## [3.0.4] - 2021-12-11
 ### Fixed

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -65,6 +65,10 @@ module.exports = {
     let var_str = await scope.toTrimmedJSON( scope, { str: original.var });
     let value_str = await scope.toTrimmedJSON( scope, { str: original.value });
     let trigger_str = await scope.toTrimmedJSON( scope, { str: original.trigger });
+    if ( trigger_str === `ALKiln: no trigger variable needed` ) {
+      // This text was added by ALKiln itself. It's not part of the user's data
+      trigger_str = ``;
+    }
     return `${ ' '.repeat(6) }| ${ var_str } | ${ value_str } | ${ trigger_str } |`;
   },  // Ends scope.convertToOriginalStoryTableRows()
 
@@ -426,7 +430,7 @@ module.exports = {
     let encoded_trigger_var = $( trigger_elem ).data( `variable` );  // This should come out to 'None' at the very least
     if ( !encoded_trigger_var ) {
       // TODO: Add documentation and then link to it in this message.
-      await scope.addToReport(scope, { type: `warning`, value: `You are missing an element containing the data for the page's trigger variable. Some fields, like loops with index variables, may not work correctly in these tests. Talk to the folks at the AssemblyLine project to learn more or see an example here: https://github.com/plocket/docassemble-ALAutomatedTestingTests/blob/ad1232049d7ca7a9b97b22f8ca3915dd3dae8114/docassemble/ALAutomatedTestingTests/data/questions/all_tests.yml#L6-L10.` });
+      await scope.addToReport(scope, { type: `warning`, value: `You are missing an element containing the data for the page's trigger variable. Some fields, like loops with index variables, may not work correctly in these tests. See https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing/#a-missing-trigger-variable.` });
       encoded_trigger_var = await scope.toBase64( scope, { utf8_str: `None` });
     }
     let trigger = await scope.fromBase64( scope, { base64_str: encoded_trigger_var });
@@ -737,6 +741,8 @@ module.exports = {
     /* Given var_data, a list of objects with variable data for
     * setting fields, and an object for a DOM field, returns list of the
     * rows that match the DOM field. That list of story table rows may be empty.
+    *
+    * For notes on trigger var, see https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing/#trigger
     * 
     * @param var_data {arr} - fields and the values they can be set to
     * @param var_data[n].var {str} - name of variable to set
@@ -757,7 +763,8 @@ module.exports = {
     * @returns [ var_data[n] ]
     */
     let matches = [];
-    let uses_proxies = false;
+    let uses_proxies = false;  // See notes further down
+    let trigger_might_be_needed = true;
 
     // There are mutliple guesses because field names are encoded
     for ( let guess of field.guesses ) {
@@ -794,18 +801,23 @@ module.exports = {
 
         if ( row_matches ) {
           matches.push( var_datum );  // Collect all matches to start with.
+          // If the field uses proxy variables - x, i, j, etc, flag it. See more notes below.
           if ( !uses_proxies ) {  // If this gets set to `true` once, leave it alone
-            // x, i, j, etc. See notes below about the reasoning
             // AVOID `.test()` - it advances through a string each time you call it on the
             // string, so you can have unexpected results.
-            uses_proxies = guess.var.match( proxies_regex );  // 
+            uses_proxies = guess.var.match( proxies_regex );
+          }
+
+          if ( var_datum.trigger === `ALKiln: no trigger variable needed` ) {
+            trigger_might_be_needed = false;
           }
           continue;
-        }
+        } // end if row_matches
 
       }  // ends for each table row
     }  // ends for each field row possibility
 
+    // uses_proxies:
     // Some fields will have multiple matches from the story table.
     // The only reason we would care about multiple story table row
     // matches is if there is a possible proxy var conflict.
@@ -825,36 +837,73 @@ module.exports = {
     // data for `users[0]`, there's no need to check the trigger var.
     // That way devs with simple cases can ignore the trigger var column.
 
-    // If field uses proxies and there has been more than one match
-    // we now use the trigger var to narrow down the matches.
-    if ( uses_proxies && matches.length > 1 ) {
-      // Multiple matches means this came from a story
+    // Make sure the trigger var matches for a page that uses proxies. Only
+    // story tables need this disambiguation.
+    if ( trigger_might_be_needed && uses_proxies && matches.length > 0 ) {
 
-      // Feedback for devs - we need the trigger var but we don't have it (field data)
-      // TODO: Add docs and link to docs on how to add the trigger var
-      if ( field.trigger === undefined ) { await scope.addToReport(scope, { type: `warning`, value: `A field on this page uses an index variable or a generic object, but the page does not contain an element with the trigger variable's name. Tell the developer to add an element to the page with the id "trigger"` }); }
+      if ( !field.trigger ) {
+        // field/page trigger var is needed but is missing.
+        let page_trigger_warning = `A field on this page uses an index `
+          + `variable or a generic object, but the interview page does not `
+          + `give the trigger variable's name. See `
+          + `https://suffolklitlab.org/docassemble-AssemblyLine-documentation`
+          + `/docs/automated_integrated_testing/#a-missing-trigger-variable.`;
+        await scope.addToReport(scope, { type: `warning`, value: page_trigger_warning });
+      }
 
       let original_matches = matches;
+      let fallbacks = [];
       matches = [];
       for ( let match of original_matches ) {
-        // Feedback for devs - we need the trigger var but we don't have it (var data)
-        if ( match.trigger === undefined ) { await scope.addToReport(scope, { type: `warning`, value: `A field on this page uses an index variable or a generic object. The test gave story data for setting the field, but that data is missing the trigger. Add a trigger variable to the story table \`trigger\` column. For now, the test may end up ignoring this field. The row's data is\n${ JSON.stringify( match.original )}.\nThe field's data is\n${ JSON.stringify( field )}` }); }
-          // TODO: Add a warning if they're both `undefined`?
-        else {
-
+        if ( !match.trigger ) {
+          // var/row trigger data is (probably) needed but is missing. Caveat: If there's
+          // only one page in the proxy var loop and there's only one row, trigger var is
+          // not needed, but I'm not sure how we figure out all those things here and log
+          // a useful message.
+          let row_trigger_warning = `This story table row needs the "trigger" `
+            + `value, but it's missing. The test might get unexpected results. See `
+            + `https://suffolklitlab.org/docassemble-AssemblyLine-documentation`
+            + `/docs/automated_integrated_testing/#trigger.`
+            + `\nThe row's data is\n${ JSON.stringify( match.original )}.`
+            + `\nThis field's data is\n${ JSON.stringify( field )}`;
+          await scope.addToReport(scope, { type: `warning`, value: row_trigger_warning });
+          fallbacks.push( match );
+        } else {
           let triggers_match = await scope.matchNeutralizedQuotes( scope, { value1: field.trigger, value2: match.trigger });
           if ( triggers_match ) {
             matches.push( match );
           }
         }
-      }
-      // Feedback for devs - we are missing the matching triggers we need
-      if ( matches.length === 0 ) { await scope.addToReport(scope, { type: `warning`, value: `A field on this page uses an index variable or a generic object. The test gave multiple matches for the story data for the field, but none match the trigger variable. Is the story table missing a row? For now, the test will have to ignore this field. The rows' data is\n${ JSON.stringify( original_matches )}.\nThe field's data is\n${ JSON.stringify( field )}` }); }
-    }
+      }  // ends for each match
 
-    // Dev may have accidentally included a row more than once. Give them feedback
+      // Be very permissive, based on feedback. See #464 comment.
+      // Use undefined trigger row(s) if no matching triggers were found
+      if ( matches.length === 0 ) { matches = fallbacks; }
+
+      // Feedback for devs on multiple row match without any matching triggers
+      if ( original_matches.length > 1 && matches.length === 0 ) {
+        let missing_row_warning = `The story table has multiple rows `
+          + `that match a specific field on the page with the id `
+          + `"${ scope.page_id }", but none match the trigger variable `
+          + `for the variable being set. Is the story table missing a row? `
+          + `The test will have to ignore this field. See `
+          + `https://suffolklitlab.org/docassemble-AssemblyLine-documentation`
+          + `/docs/automated_integrated_testing/#trigger.`
+          + `\nThe data of all the rows is\n${ JSON.stringify( original_matches )}.`
+          + `\nThis field's data is\n${ JSON.stringify( field )}`;
+        await scope.addToReport(scope, { type: `warning`, value: missing_row_warning });
+      }
+    }  // ends if need trigger var
+
+    // Dev may have accidentally included a row more than once.
     if ( matches.length > 1 ) {
-      await scope.addToReport(scope, { type: `warning`, value: `there are multiple story data matches for this field. The story table data that appears last will be used. The field's data is\n${JSON.stringify( field )}` });
+      let multiple_matches_msg = `Multiple story table rows match this field's `
+        + `variable. The test will use the last row that matched. See `
+        + `https://suffolklitlab.org/docassemble-AssemblyLine-documentation`
+        + `/docs/automated_integrated_testing/#trigger.`
+        + `\nThe last row's data is:\n${ JSON.stringify( matches[ matches.length - 1 ] )}`
+        + `\nThis field's data is\n${JSON.stringify( field )}`;
+      await scope.addToReport(scope, { type: `warning`, value: multiple_matches_msg });
     }
 
     if ( env_vars.DEBUG ) { console.log( `matches:\n`, JSON.stringify( matches )); }

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -644,7 +644,7 @@ When(/I set the var(?:iable)? "([^"]+)" to "([^"]+)"/, async ( var_name, set_to 
   * 1. I set the var "rent_interval" to "weekly"
   */
   let var_data = await scope.normalizeTable( scope, {
-    var_data: [{ var: var_name, value: set_to, trigger: '' }],
+    var_data: [{ var: var_name, value: set_to, trigger: `ALKiln: no trigger variable needed` }],
   });
   // Don't continue if the variable doesn't navigate and if this variable cannot be set
   // on this page, trigger an error
@@ -655,7 +655,7 @@ Then(/I upload "([^"]+)" to "([^"]+)"/, async ( filenames, var_name ) => {
   /* Uploads sibling file (docx, jpg, etc) to input var. Can actually use
   * 'I set the var "" to ""', but this is more explicit if it's desired. */
   let var_data = await scope.normalizeTable( scope, {
-    var_data: [{ var: var_name, value: filenames, trigger: '' }],
+    var_data: [{ var: var_name, value: filenames, trigger: `ALKiln: no trigger variable needed` }],
   });
   // Don't continue if the variable doesn't navigate and if this variable cannot be set
   // on this page, trigger an error

--- a/tests/unit_tests/getMatchingRows.test.js
+++ b/tests/unit_tests/getMatchingRows.test.js
@@ -188,6 +188,32 @@ describe(`For mulitple rows with the same proxies`, async function() {
   }
 });
 
+// Missing table row for loop
+describe(`For a second proxy loop page,`, async function() {
+  for ( let test_i = 0; test_i < fields.proxies_multi.length; test_i++ ) {
+    let field = fields.proxies_multi[ test_i ];
+    let curr_matches = matches.proxies_missing_loop[ test_i ];
+    let name = getSafeName( field );
+    it( `does not find any matches when table row for second loop page is missing`, async function() {
+      let result = await getMatchingRows( scope, { field, var_data: tables.proxies_missing_loop });
+      expect( result ).to.deep.equal( curr_matches );
+    });
+  }
+});
+
+// Missing trigger matches second loop
+describe(`For a second proxy loop page,`, async function() {
+  for ( let test_i = 0; test_i < fields.proxies_multi.length; test_i++ ) {
+    let field = fields.proxies_multi[ test_i ];
+    let curr_matches = matches.proxies_missing_trigger[ test_i ];
+    let name = getSafeName( field );
+    it( `matches with a missing trigger row with the correct variable name`, async function() {
+      let result = await getMatchingRows( scope, { field, var_data: tables.proxies_missing_trigger });
+      expect( result ).to.deep.equal( curr_matches );
+    });
+  }
+});
+
 
 // ============================
 // Signature

--- a/tests/unit_tests/matches.fixtures.js
+++ b/tests/unit_tests/matches.fixtures.js
@@ -111,6 +111,18 @@ matches.proxies_multi = [
   []
 ];
 
+// Missing table row for second loop
+matches.proxies_missing_loop = [
+  [],
+  []
+];
+
+// Missing trigger matches second loop
+matches.proxies_missing_trigger = [
+  [{"trigger":"","var":"x[i].name.first","value":"Firstname"}],
+  []
+];
+
 
 // ============================
 // Signature

--- a/tests/unit_tests/tables.fixtures.js
+++ b/tests/unit_tests/tables.fixtures.js
@@ -373,6 +373,16 @@ tables.proxies_multi = [
   { "trigger": "proxy_list[2].name.first", "var": "x[i].name.first", "value": "Firstname", },
 ];
 
+// Missing table row for second loop
+tables.proxies_missing_loop = [
+  { "trigger": "proxy_list[0].name.first", "var": "x[i].name.first", "value": "Firstname", },
+];
+
+// Missing trigger matches second loop
+tables.proxies_missing_trigger = [
+  { "trigger": "", "var": "x[i].name.first", "value": "Firstname", },
+];
+
 
 // ============================
 // Signature


### PR DESCRIPTION
only one row for the relevant variable. Closes #464.

Also
- enhance reports about the problem.
- avoids trigger var check entirely when it's not from a story
table