### PR TITLE
Separate Scenario filenames, ids, and report headers for v4

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -75,6 +75,36 @@ module.exports = {
     return trimmed;
   },  // Ends scope.toTrimmedJSON()
 
+  setReportHeading: async function (scope, { scenario }) {
+    if ( env_vars.DEBUG ) { console.log( scenario.pickle.name ); }
+    // Names for files and reports
+    // TODO: Allow scenario ids to have digits in their name
+
+    // With tag names automatically added to langauges, this should work to make
+    // each language unique.
+    let tags = '';
+    for ( let tag of scenario.pickle.tags ) {
+      tags += tag.name + '_';
+    }
+    tags = tags.replace(/_$/, '');
+    let new_id = `${ scenario.pickle.name }_${ tags }`;
+
+    // Should we add a counter? It would have to be unique to each scenario name.
+    // Not sure of another good way to indicate the _name_ is a duplicate
+    while ( scope.report.get( new_id ) !== undefined  ) {
+      new_id += '_';
+    }
+
+    scope.scenario_id = new_id;
+
+    new_id = await scope.getSafeScenarioFilename(scope, { prefix: '' });
+    // Consider replacing underscores with spaces? 
+    await scope.addToReport( scope, { 
+      type: `heading`, 
+      value: `\n---------------\nScenario: ${ new_id }\n---------------` 
+    });
+  },  // Ends scope.setReportHeading()
+
   getPrintableReport: async function( scope ) {
     /* Return a string genereated from test report data. */
     let report = `Assembly Line Kiln Automated Testing Report - ${ (new Date()).toUTCString() }\n`;

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -84,10 +84,10 @@ module.exports = {
     // each language unique.
     let tags = '';
     for ( let tag of scenario.pickle.tags ) {
-      tags += tag.name + '_';
+      tags += tag.name.replace(/[^A-Za-z0-9]+/g, '_').replace(/(\P{L})+/gu, '_');
     }
     tags = tags.replace(/_$/, '');
-    let new_id = `${ scenario.pickle.name }_${ tags }`;
+    let new_id = `${ scenario.pickle.name }${ tags }`;
 
     // Should we add a counter? It would have to be unique to each scenario name.
     // Not sure of another good way to indicate the _name_ is a duplicate
@@ -97,11 +97,9 @@ module.exports = {
 
     scope.scenario_id = new_id;
 
-    new_id = await scope.getSafeScenarioFilename(scope, { prefix: '' });
-    // Consider replacing underscores with spaces? 
-    await scope.addToReport( scope, { 
-      type: `heading`, 
-      value: `\n---------------\nScenario: ${ new_id }\n---------------` 
+    await scope.addToReport( scope, {
+      type: `heading`,
+      value: `\n---------------\nScenario: ${ new_id.replace(/_/g, ` `) }\n---------------`
     });
   },  // Ends scope.setReportHeading()
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -75,33 +75,32 @@ module.exports = {
     return trimmed;
   },  // Ends scope.toTrimmedJSON()
 
-  setReportHeading: async function (scope, { scenario }) {
+  addReportHeading: async function (scope, { scenario }) {
+    /** Return printable heading based on Scenario name and tags.
+    *    Allow characters from other languages.
+    */
     if ( env_vars.DEBUG ) { console.log( scenario.pickle.name ); }
-    // Names for files and reports
-    // TODO: Allow scenario ids to have digits in their name
 
-    // With tag names automatically added to langauges, this should work to make
-    // each language unique.
-    let tags = '';
+    // Collect all tag names
+    let tag_names = [];
     for ( let tag of scenario.pickle.tags ) {
-      tags += tag.name.replace(/[^A-Za-z0-9]+/g, '_').replace(/(\P{L})+/gu, '_');
-    }
-    tags = tags.replace(/_$/, '');
-    let new_id = `${ scenario.pickle.name }${ tags }`;
-
-    // Should we add a counter? It would have to be unique to each scenario name.
-    // Not sure of another good way to indicate the _name_ is a duplicate
-    while ( scope.report.get( new_id ) !== undefined  ) {
-      new_id += '_';
+      tag_names.push( tag.name );
     }
 
-    scope.scenario_id = new_id;
+    let heading = `\n---------------\n`
+      + `Scenario: ${ scenario.pickle.name }`;
+
+    if ( tag_names.length > 0 ) {
+      heading += `\nTags: ${ tag_names.join(' ') }`;
+    }
+
+    heading += `\n---------------`;
 
     await scope.addToReport( scope, {
       type: `heading`,
-      value: `\n---------------\nScenario: ${ new_id.replace(/_/g, ` `) }\n---------------`
+      value: heading,
     });
-  },  // Ends scope.setReportHeading()
+  },  // Ends scope.addReportHeading()
 
   getPrintableReport: async function( scope ) {
     /* Return a string genereated from test report data. */
@@ -140,21 +139,42 @@ module.exports = {
     return report;
   },  // Ends scope.getPrintableScenario()
 
-  getSafeScenarioFilename: async function( scope, { prefix='' }) {
-    /* Return a string with `prefix` at the start and scenario info at the end,
-    * made safe for a filename. We hope it can contain chinese chars and such.
-    * No suffix because it may be cut off when we ensure the string is not too
-    * long. */
+  getSafeScenarioBaseFilename: async function( scope, { scenario }) {
+    /** Return a string that's safe to be a filename. Include the Scenario
+    *    description, tags, and language.
+    */
+    let name_parts = [];
 
-    // Make sure the strings ends in at least one '_', but don't add extra '_'
-    if ( prefix ) { prefix = `${ prefix.replace(/_$/, '') }_`; }
-    else { prefix = ''; }  // Enure it's a string
+    // Try to order filenames by language if possible/needed
+    if ( scope.language ) {
+      name_parts.push( scope.language );
+    }
+    name_parts.push( scenario.pickle.name );
+    for ( let tag of scenario.pickle.tags ) {
+      name_parts.push( tag.name );
+    }
 
-    let lang = scope.language;
-    if ( lang ) { lang = `${ lang.replace(/_$/, '') }_`; }
-    else { lang = ''; }
+    let filename = name_parts.join(`-`);
 
-    let safe_name = safe_filename(`${ prefix }${ lang }${ Date.now() }_${ scope.scenario_id }`, { replacement: `_` });
+    return safe_filename( filename, { replacement: `_` });
+  },  // Ends scope.getSafeScenarioBaseFilename()
+
+  getSafeScenarioFilename: async function( scope, options={} ) {
+    /* Return a string that's safe to be a filename. Use a timestamp,
+    *    a prefix the caller wants, and the base filename. We hope it can
+    *    contain non-english characters too. We do not offer a suffix option
+    *    because it may be cut off if the filename is too long.
+    */
+    // Ensure prefix is a string
+    let prefix = options.prefix || '';
+    // As long as it's not an empty string, add a separator between it and the rest of the name
+    // For now, it needs to be `_` for the action and .gitignore. In future,
+    // aiming for `-`.
+    if ( prefix ) {
+      prefix = `${ prefix }_`;
+    }
+
+    let safe_name = safe_filename(`${ prefix }${ Date.now() }-${ scope.base_filename }`, { replacement: `_` });
     let safer_name = safe_name.substring(0, (255 - 10));  // Allow room for extensions
     return safer_name;
   },  // Ends scope.getSafeScenarioFilename()

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const { expect } = require('chai');
 const puppeteer = require('puppeteer');
+const { v4: uuidv4 } = require('uuid');
 
 const scope = require('./scope');
 const env_vars = require('./utils/env_vars');
@@ -59,7 +60,10 @@ BeforeAll(async () => {
 });
 
 Before(async (scenario) => {
-  scope.setReportHeading(scope, {scenario});
+  scope.scenario_id = uuidv4();
+
+  await scope.addReportHeading(scope, {scenario});
+  scope.base_filename = await scope.getSafeScenarioBaseFilename(scope, {scenario});
 
   // Downloads
   scope.downloadComplete = false;

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -59,25 +59,7 @@ BeforeAll(async () => {
 });
 
 Before(async (scenario) => {
-  if ( env_vars.DEBUG ) { console.log( scenario.pickle.name ); }
-  // Names for files and reports
-  // TODO: Allow scenario ids to have digits in their name
-  let scenario_name = scenario.pickle.name.replace(/(\P{L})+/gu, '_'); // allow more languages
-  let tags = ''
-  for ( let tag of scenario.pickle.tags ) {
-    tags += tag.name.replace(/[^A-Za-z0-9]+/g, '_').replace(/(\P{L})+/gu, '_');
-  }
-  // With tag names automatically added to langauges, this should work to make
-  // each language unique.
-  let new_id = `${ scenario_name }${ tags }`
-
-  // Should we add a counter? It would have to be unique to each scenario name.
-  // Not sure of another good way to indicate the _name_ is a duplicate
-  while ( scope.report.get( new_id ) !== undefined  ) {
-    new_id += '_';
-  }
-  scope.scenario_id = new_id;
-  await scope.addToReport( scope, { type: `heading`, value: `\n---------------\nScenario: ${ new_id.replace(/_/g, ` `) }\n---------------` });
+  scope.setReportHeading(scope, {scenario});
 
   // Downloads
   scope.downloadComplete = false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "docassemble-cucumber",
-  "version": "3.0.0-peer-deps.1",
+  "version": "3.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "3.0.0-peer-deps.1",
+      "version": "3.0.4",
       "license": "MIT",
       "dependencies": {
         "chai": "^4.2.0",
@@ -14,7 +14,8 @@
         "dotenv": "^8.2.0",
         "mocha": "^7.2.0",
         "puppeteer": "^3.1.0",
-        "sanitize-filename": "^1.6.3"
+        "sanitize-filename": "^1.6.3",
+        "uuid": "^8.3.2"
       },
       "bin": {
         "da-cucumber": "lib/index.js",
@@ -2058,6 +2059,14 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -3882,6 +3891,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "dotenv": "^8.2.0",
     "mocha": "^7.2.0",
     "puppeteer": "^3.1.0",
-    "sanitize-filename": "^1.6.3"
+    "sanitize-filename": "^1.6.3",
+    "uuid": "^8.3.2"
   },
   "bin": {
     "da-setup": "./lib/github_integration/setup.js",

--- a/tests/features/reports.feature
+++ b/tests/features/reports.feature
@@ -350,7 +350,8 @@ Scenario: Report still shows page id when I tap to continue without setting any 
   Given the Scenario report should include:
     """
     ---------------
-    Scenario: Report still shows page id when I tap to continue without setting any fields reports fast rp 
+    Scenario: Report still shows page id when I tap to continue without setting any fields
+    Tags: @reports @fast @rp1
     ---------------
     screen id: upload-files
     screen id: group-of-complex-fields
@@ -396,7 +397,8 @@ Scenario: Report lists unused table rows
     """
 
     ---------------
-    Scenario: Report lists unused table rows reports slow rp 
+    Scenario: Report lists unused table rows
+    Tags: @reports @slow @rp2
     ---------------
     screen id: upload-files
     screen id: group-of-complex-fields

--- a/tests/unit_tests/getSafeScenarioBaseFilename.fixtures.js
+++ b/tests/unit_tests/getSafeScenarioBaseFilename.fixtures.js
@@ -1,0 +1,12 @@
+let names = {};
+
+names.with_spaces = `a tests description`;
+names.tag1 = `tag1`;
+names.tag2 = `tag2`;
+
+names.non_english_chars = `是汉字`;
+
+names.colon_input = `invalid:colon`;
+names.colon_output = `invalid_colon`;
+
+module.exports = names;

--- a/tests/unit_tests/getSafeScenarioBaseFilename.test.js
+++ b/tests/unit_tests/getSafeScenarioBaseFilename.test.js
@@ -1,0 +1,62 @@
+const chai = require(`chai`);
+const expect = chai.expect;
+
+const names = require(`./getSafeScenarioBaseFilename.fixtures.js`);
+const scope = require(`../../lib/scope.js`);
+const getSafeScenarioBaseFilename = scope.getSafeScenarioBaseFilename;
+
+
+let mock_scenario = function ( description, tag_names=[] ) {
+  /** Mock the complex structure of a Scenario object */
+  let scenario = {
+    pickle: { name: description, tags: [], }
+  };
+  for ( let tag of tag_names ) {
+    scenario.pickle.tags.push({ name: tag });
+  }
+  return scenario;
+};  // Ends mock_scenario();
+
+describe(`When I use scope.getSafeScenarioBaseFilename()`, function() {
+
+  beforeEach(function() {
+    scope.language = undefined;
+  });
+
+  // No language, no tags
+  it(`preserves spaces`, async function() {
+    let scenario = mock_scenario( names.with_spaces, [] );
+    let result = await getSafeScenarioBaseFilename( scope, { scenario });
+    expect( result ).to.equal( names.with_spaces );
+  });
+
+  it(`preserves non-english characters`, async function() {
+    let scenario = mock_scenario( names.non_english_chars, [] );
+    let result = await getSafeScenarioBaseFilename( scope, { scenario });
+    expect( result ).to.equal( names.non_english_chars );
+  });
+
+  it(`replaces invalid characters with "_"`, async function() {
+    let scenario = mock_scenario( names.colon_input, [] );
+    let result = await getSafeScenarioBaseFilename( scope, { scenario });
+    expect( result ).to.equal( names.colon_output );
+  });
+
+  // language, 1 tag
+  it(`adds a language and 1 tag correctly, preserving numbers`, async function() {
+    scope.language = names.non_english_chars;
+    let scenario = mock_scenario( names.with_spaces, [ names.tag1 ] );
+    let result = await getSafeScenarioBaseFilename( scope, { scenario });
+    let expected = `${ names.non_english_chars }-${ names.with_spaces }-${ names.tag1 }`;
+    expect( result ).to.equal( expected );
+  });
+
+  // 2 tags
+  it(`adds 2 tags correctly, preserving numbers`, async function() {
+    let scenario = mock_scenario( names.with_spaces, [ names.tag1, names.tag2 ] );
+    let result = await getSafeScenarioBaseFilename( scope, { scenario });
+    let expected = `${ names.with_spaces }-${ names.tag1 }-${ names.tag2 }`;
+    expect( result ).to.equal( expected );
+  });
+
+});

--- a/tests/unit_tests/getSafeScenarioFilename.test.js
+++ b/tests/unit_tests/getSafeScenarioFilename.test.js
@@ -91,4 +91,10 @@ describe(`When I use scope.getSafeScenarioFilename()`, function() {
     test_no_lang_output_is_correct( names.two_consecutive_invalid_output, result );
   });
 
+  it(`does not replace numbers`, async function() {
+    scope.language = undefined;
+    let result = await getSafeScenarioFilename( scope, { prefix: names.numerical_input });
+    test_no_lang_output_is_correct( names.numerical_output, result );
+  });
+
 });

--- a/tests/unit_tests/getSafeScenarioFilename.test.js
+++ b/tests/unit_tests/getSafeScenarioFilename.test.js
@@ -1,100 +1,83 @@
-const chai = require('chai');
-const expect = chai.expect;
 
+ const chai = require('chai');
+ const expect = chai.expect;
+ 
+ const names = require('./names.fixtures.js');
+ const scope = require('../../lib/scope.js');
+ const getSafeScenarioFilename = scope.getSafeScenarioFilename;
+ 
+ 
+let test_filename = function ( expected_prefix, result ) {
+   /* Test a name to see if it's valid output with a language defined. */
+  let expected_name_regex_str = `^${ expected_prefix }\\d{13}-${ names.base_filename }$`;
+   let regex = new RegExp( expected_name_regex_str );
+ 
+  // Log more info if it failed
+  let found_match = regex.test( result );
+  if ( !found_match ) {
+    console.log( 'regex:', regex.source );
+    console.log( 'result:', result );
+  }
 
-const names = require('./names.fixtures.js');
-const scope = require('../../lib/scope.js');
-const getSafeScenarioFilename = scope.getSafeScenarioFilename;
-// ${ prefix }${ scope.lang }${ Date.now() }_${ scope.safe_id }
+  expect( found_match ).to.be.true;
+ };
+ 
 
-let lang = names.language;
-let id = names.scenario_id;
-
-let test_lang_output_is_correct = function ( expected_prefix, result ) {
-  /* Test a name to see if it's valid output with a language defined. */
-  let expected_name_regex_str = `^${ expected_prefix }${ lang }_\\d{13}_${ id }$`;
-  let regex = new RegExp( expected_name_regex_str );
-  expect( regex.test( result )).to.be.true;
-};
-
-let test_no_lang_output_is_correct = function ( expected_prefix, result ) {
-  /* Test a name to see if it's valid output with an empty language. */
-  let expected_name_regex_str = `^${ expected_prefix }\\d{13}_${ id }$`;
-  let regex = new RegExp( expected_name_regex_str );
-  expect( regex.test( result )).to.be.true;
-};
-
-describe(`When I use scope.getSafeScenarioFilename()`, function() {
-
-  beforeEach(function() {
-    scope.language = names.language;
-    scope.scenario_id = id;
-  });
-
-  it(`preserves chinese characters`, async function() {
-    let result = await getSafeScenarioFilename( scope, { prefix: names.chinese_input });
-    test_lang_output_is_correct( names.chinese_output, result );
-  });
-
-  it(`adds an underscore when there is none`, async function() {
-    let result = await getSafeScenarioFilename( scope, { prefix: names.no_underscore_input });
-    test_lang_output_is_correct( names.no_underscore_output, result );
-  });
-
-  it(`preserves one underscore`, async function() {
-    let result = await getSafeScenarioFilename( scope, { prefix: names.one_underscore_input });
-    test_lang_output_is_correct( names.one_underscore_output, result );
-  });
-
-  it(`preserves two underscores`, async function() {
-    let result = await getSafeScenarioFilename( scope, { prefix: names.two_underscores_input });
-    test_lang_output_is_correct( names.two_underscores_output, result );
-  });
-
-  it(`does not add underscores to an empty string`, async function() {
-    let result = await getSafeScenarioFilename( scope, { prefix: names.empty_string_input });
-    test_lang_output_is_correct( names.empty_string_output, result );
-  });
-
-  it(`converts undefined to an empty string`, async function() {
-    let result = await getSafeScenarioFilename( scope, { prefix: names.undefined_input });
-    test_lang_output_is_correct( names.undefined_output, result );
-  });
-
-  it(`correctly excludes an empty string lang`, async function() {
-    scope.language = ``;
-    let result = await getSafeScenarioFilename( scope, { prefix: names.undefined_input });
-    test_no_lang_output_is_correct( names.undefined_output, result );
-  });
-
-  it(`correctly excludes an undefined lang`, async function() {
-    scope.language = undefined;
-    let result = await getSafeScenarioFilename( scope, { prefix: names.one_underscore_input });
-    test_no_lang_output_is_correct( names.one_underscore_output, result );
-  });
-
-  it(`replaces invalid ':' with '_'`, async function() {
-    scope.language = undefined;
-    let result = await getSafeScenarioFilename( scope, { prefix: names.colon_input });
-    test_no_lang_output_is_correct( names.colon_output, result );
-  });
-
-  it(`replaces invalid '/' with '_'`, async function() {
-    scope.language = undefined;
-    let result = await getSafeScenarioFilename( scope, { prefix: names.slash_input });
-    test_no_lang_output_is_correct( names.slash_output, result );
-  });
-
-  it(`replaces two consecutive invalid chars with one '_' each`, async function() {
-    scope.language = undefined;
-    let result = await getSafeScenarioFilename( scope, { prefix: names.two_consecutive_invalid_input });
-    test_no_lang_output_is_correct( names.two_consecutive_invalid_output, result );
-  });
-
-  it(`does not replace numbers`, async function() {
-    scope.language = undefined;
-    let result = await getSafeScenarioFilename( scope, { prefix: names.numerical_input });
-    test_no_lang_output_is_correct( names.numerical_output, result );
-  });
-
-});
+ describe(`When I use scope.getSafeScenarioFilename()`, function() {
+ 
+   beforeEach(function() {
+    scope.base_filename = names.base_filename;
+   });
+ 
+   it(`preserves chinese characters`, async function() {
+     let result = await getSafeScenarioFilename( scope, { prefix: names.chinese_input });
+    test_filename( names.chinese_output, result );
+   });
+ 
+   it(`adds an underscore when there is none`, async function() {
+     let result = await getSafeScenarioFilename( scope, { prefix: names.no_underscore_input });
+    test_filename( names.no_underscore_output, result );
+   });
+ 
+   it(`preserves one underscore`, async function() {
+     let result = await getSafeScenarioFilename( scope, { prefix: names.one_underscore_input });
+    test_filename( names.one_underscore_output, result );
+   });
+ 
+   it(`preserves two underscores`, async function() {
+     let result = await getSafeScenarioFilename( scope, { prefix: names.two_underscores_input });
+    test_filename( names.two_underscores_output, result );
+   });
+ 
+   it(`does not add underscores to an empty string`, async function() {
+     let result = await getSafeScenarioFilename( scope, { prefix: names.empty_string_input });
+    test_filename( names.empty_string_output, result );
+   });
+ 
+   it(`converts undefined to an empty string`, async function() {
+     let result = await getSafeScenarioFilename( scope, { prefix: names.undefined_input });
+    test_filename( names.undefined_output, result );
+   });
+ 
+   it(`replaces invalid ':' with '_'`, async function() {
+     let result = await getSafeScenarioFilename( scope, { prefix: names.colon_input });
+    test_filename( names.colon_output, result );
+   });
+ 
+   it(`replaces invalid '/' with '_'`, async function() {
+     let result = await getSafeScenarioFilename( scope, { prefix: names.slash_input });
+    test_filename( names.slash_output, result );
+   });
+ 
+   it(`replaces two consecutive invalid chars with one '_' each`, async function() {
+     let result = await getSafeScenarioFilename( scope, { prefix: names.two_consecutive_invalid_input });
+    test_filename( names.two_consecutive_invalid_output, result );
+   });
+ 
+   it(`does not replace numbers`, async function() {
+     let result = await getSafeScenarioFilename( scope, { prefix: names.numerical_input });
+    test_filename( names.numerical_output, result );
+   });
+ 
+ });
+ 

--- a/tests/unit_tests/names.fixtures.js
+++ b/tests/unit_tests/names.fixtures.js
@@ -1,7 +1,6 @@
 let names = {};
 
-names.language = 'some_lang';
-names.scenario_id = 'a_safe_id';
+names.base_filename = `a_safe_id`;
 
 names.chinese_input = `是汉字`;
 names.chinese_output = `是汉字_`;
@@ -10,10 +9,10 @@ names.no_underscore_input = `ends_in_no_underscore`;
 names.no_underscore_output = `ends_in_no_underscore_`;
 
 names.one_underscore_input = `ends_in_one_underscore_`;
-names.one_underscore_output = `ends_in_one_underscore_`;
+names.one_underscore_output = `ends_in_one_underscore__`;
 
 names.two_underscores_input = `ends_in_two_underscores__`;
-names.two_underscores_output = `ends_in_two_underscores__`;
+names.two_underscores_output = `ends_in_two_underscores___`;
 
 names.empty_string_input = ``;
 names.empty_string_output = ``;

--- a/tests/unit_tests/names.fixtures.js
+++ b/tests/unit_tests/names.fixtures.js
@@ -30,5 +30,7 @@ names.slash_output = `invalid_slash_`;
 names.two_consecutive_invalid_input = `two_consecutive//invalid`;
 names.two_consecutive_invalid_output = `two_consecutive__invalid_`;
 
+names.numerical_input = `scenario_w1th_number00`;
+names.numerical_output = `scenario_w1th_number00_`;
 
 module.exports = names;


### PR DESCRIPTION
Separate Scenario filenames, ids, and report headers

Same as #382. Closes #371. This has already been reviewed when #463 was merged.