### PR TITLE
Add step to get page's vars and vals for v3. Unintegrated with the

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,10 @@ Format:
 ### Security
 - 
 -->
-<!-- ## [Unreleased] -->
+## [Unreleased]
+### Added
+- Step to log the page's JSON variables and values in the report. Future goal: save to file. See #454.
+
 ## [3.0.9] - 2022-01-10
 ### Security
 - Install the security fix in the action's package.json as well. Because dependents have to require cucumber itself, if they're not using our action (if they have their own package.json), they're going to have to implement this fix in their repo too. That's why our fix isn't working. We'll start the process of helping developers update. We also need to deprecate all previous versions of ALKiln. See #489.

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -573,6 +573,29 @@ Then(/the "([^"]+)" link opens in (a new window|the same window)/, async (linkTe
   await scope.afterStep(scope);
 });
 
+Then(/I get the(?: page's)?(?: JSON)? var(?:iable)?s and val(?:ue)?s/i, async () => {
+  /** Uses  https://docassemble.org/docs/functions.html#js_get_interview_variables
+  *    to get the variable values on the page of the interview and add
+  *    them to the report.
+  * 
+  * Varations:
+  * I get the page's JSON variables and values
+  * I get the json vars and vals
+  * I get the page's vars and vals
+  * I get the vars and vals
+  */
+
+  let data = await scope.page.evaluate(async function ( elem ) {
+    return await get_interview_variables();
+  });
+
+  // In future, may be saved to artifact file
+  await scope.addToReport( scope, {
+    type: `json`,
+    value: JSON.stringify( data, null, 2 )
+  });
+});
+
 //#####################################
 //#####################################
 // Actions

--- a/tests/features/observation_steps.feature
+++ b/tests/features/observation_steps.feature
@@ -95,3 +95,9 @@ Scenario: Test "Then I don’t continue" with an apostrophe
   And I tap to continue
   Then I don’t continue
   And I will be told an answer is invalid
+
+# Maybe this one should be in the report tests (as well?)
+@fast @o10 @json
+Scenario: I get the page's JSON
+  Given I start the interview at "all_tests"
+  Then I get the page's JSON variables and values


### PR DESCRIPTION
other JSON step because I need to publish this one. It's already been
field tested by the user who requested it, so I'm going to forgo
a review in order to be able to move this forwards.

That is, the other Step is in a PR under review and I don't know
when someone will have time to take a look.

Addresses #454 for v3. Won't close till it's added to v4.

[Will wait till tests have passed.]