### PR TITLE
Add Step to get page's vars and vals for v4. Unintegrated with the

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Format:
 ### Added
 - Add action.yml that runs most of what users' workflows run now, along with notes for a new user workflow that will take less maintainance. See #420. We need to add documentation on how to write a workflow file as it currently is if they want to take back control. Setup interview has not yet been updated with this workflow.
 - Add package.json creation/overwriting to action.yml. Simplify package.json.
+- Step to log the page's JSON variables and values in the report. Future goal: save to file. See #454.
 
 <!-- ## [3.0.1-peer-deps.1] - 2021-12-07 -->
 ### Removed

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -573,6 +573,29 @@ Then(/the "([^"]+)" link opens in (a new window|the same window)/, async (linkTe
   await scope.afterStep(scope);
 });
 
+Then(/I get the(?: page's)?(?: JSON)? var(?:iable)?s and val(?:ue)?s/i, async () => {
+  /** Uses  https://docassemble.org/docs/functions.html#js_get_interview_variables
+  *    to get the variable values on the page of the interview and add
+  *    them to the report.
+  * 
+  * Varations:
+  * I get the page's JSON variables and values
+  * I get the json vars and vals
+  * I get the page's vars and vals
+  * I get the vars and vals
+  */
+
+  let data = await scope.page.evaluate(async function ( elem ) {
+    return await get_interview_variables();
+  });
+
+  // In future, may be saved to artifact file
+  await scope.addToReport( scope, {
+    type: `json`,
+    value: JSON.stringify( data, null, 2 )
+  });
+});
+
 //#####################################
 //#####################################
 // Actions

--- a/tests/features/observation_steps.feature
+++ b/tests/features/observation_steps.feature
@@ -95,3 +95,9 @@ Scenario: Test "Then I don’t continue" with an apostrophe
   And I tap to continue
   Then I don’t continue
   And I will be told an answer is invalid
+
+# Maybe this one should be in the report tests (as well?)
+@fast @o10 @json
+Scenario: I get the page's JSON
+  Given I start the interview at "all_tests"
+  Then I get the page's JSON variables and values


### PR DESCRIPTION
other JSON Step because I need to publish this one and the other
is in an unreviewed PR and I don't know when someone will have
time to take a look. It's already been field tested by the user
who requested it, so I'm going to forgo a review in order to be
able to move this forwards.

Addresses #454. Have to save to artifacts before the issue gets closed.

Will wait till tests have passed.