### PR TITLE
Re-use json function for both string comparison and report log for v4

### DIFF
--- a/lib/steps.js
+++ b/lib/steps.js
@@ -624,9 +624,7 @@ Then(/I get the(?: page's)?(?: JSON)? var(?:iable)?s and val(?:ue)?s/i, async ()
   * I get the vars and vals
   */
 
-  let data = await scope.page.evaluate(async function ( elem ) {
-    return await get_interview_variables();
-  });
+  let data = await scope.getPageJSON( scope );
 
   // In future, may be saved to artifact file
   await scope.addToReport( scope, {


### PR DESCRIPTION
Just following up those two JSON updates that had to be independent of each other.

Won't be doing this for v3. Focusing on moving to v4.