### PR TITLE
Remove failing `description` in example comment in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -126,7 +126,6 @@ runs:
 # # might use another version.
 
 # name: Use the ALKiln testing framework
-# description: "Use the ALKiln testing framework to test interviews. See https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing."
 
 # on:
 #   push:


### PR DESCRIPTION
The comments there are supposed to contain code that our users (developers) can copy/paste into their file. Right now if they do that their file will fail. This will fix that.