### PR TITLE
Catch `al_custom_error_screen` errors

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2673,6 +2673,8 @@ module.exports = {
       // The below does not work if there's not a space between ':' and 'none'
       simple_user_error: await scope.page.$$(`xpath/.//*[contains(@class, "da-has-error")][not(contains(@style,"display: none"))]`),
       system_error: await scope.page.$$(`xpath/.//meta[@content="docassemble: Error"]` ),
+      // Hardcoding the `al_custom_error_action` screen (that's what the base64 here is). It hides actual errors and looks like a continue screen, but isn't.
+      al_custom_error: await scope.page.$$('.question-custom-error-action .daattributions #trigger[data-variable="YWxfY3VzdG9tX2Vycm9yX2FjdGlvbg"]'),
     };
 
     let error_handlers = {};


### PR DESCRIPTION
[Addresses #656]

### Reason for this PR

The custom AL screens are not recognized as actual error screens, so Kiln will attempt to continue navigating when it sees them, even when all it can do is stay on the same screen. This wastes `MAX_TIMEOUT` minutes each time the interviews fail, instead of recognizing the failure immediately.

This fix:

* isn't really testable: the test is if Kiln can detect a failure within a few screens instead of a few hundred, and that's not currently a check we have / can do.
* still seems to not work when not going through the story table for some reason? Just putting `And I tap to continue` multiple times, the error is checked, but Kiln doesn't do anything with it and just continues going, says the test passed. https://github.com/SuffolkLITLab/ALKiln/blame/v5/lib/scope.js#L2325-L2340

I've already been sitting on this PR for like a month, it's affecting all of our interviews (when there are failures), so I think it should get merged, even though I can't figure out testing or really fixing the core issue (error handling).

### Any manual testing I have done to ensure my PR is working

Made an example interview and test to manually go through to ensure this is working.

```yml
---
include:
  - docassemble.AssemblyLine:al_package.yml
  - docassemble.AssemblyLine:al_visual.yml
---
mandatory: True
code: |
  signature
  missing_var
---
question: Signature
signature: signature
---
```


```feature
 Scenario: Fail with al_custom_error page from random input
          Given the final Scenario status should be "failed"
          Given I start the interview at "test_missing_var_al_custom_error"
          And the max seconds for each step in this scenario is 10
          And I get to the question id "idk" with this data:
          | var | value |
          | signature | "signature" |
```